### PR TITLE
Ignore reviews with state "COMMENT"

### DIFF
--- a/src/reviewers.js
+++ b/src/reviewers.js
@@ -22,11 +22,11 @@ async function fetchReviewers() {
 			per_page: 100,
 		} ) ) {
 			res.data.forEach( review => {
-				// Looks like GitHub may return more than one review per user, but only counts the last for each.
-				// "APPROVED" allows merging, while anything else (e.g. "CHANGED_REQUESTED" or "DISMISSED") doesn't.
+				// GitHub may return more than one review per user, but only counts the last non-comment one for each.
+				// "APPROVED" allows merging, while "CHANGES_REQUESTED" and "DISMISSED" do not.
 				if ( review.state === 'APPROVED' ) {
 					reviewers.add( review.user.login );
-				} else {
+				} else if ( review.state === 'CHANGES_REQUESTED' || review.state === 'DISMISSED' ) {
 					reviewers.delete( review.user.login );
 				}
 			} );


### PR DESCRIPTION
It doesn't count the last review, it counts the last non-comment (review state: "COMMENT") review.

For example, if a reviewer submits (1) a review with state APPROVED and (2) a review with state COMMENT, the reviewer still has a green check mark and it's still possible to merge.